### PR TITLE
[Feature] Add Group, Member, Expense CRUD API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
     implementation("org.postgresql:postgresql")
+    implementation("org.springframework.data:spring-data-mongodb:4.3.3")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,9 @@ dependencies {
 
     //logging
     implementation("io.github.microutils:kotlin-logging:3.0.5")
-    implementation("ch.qos.logback:logback-classic:1.4.11")
+    implementation("ch.qos.logback:logback-classic:1.4.12")
+
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
     implementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 
+    //logging
+    implementation("io.github.microutils:kotlin-logging:3.0.5")
+    implementation("ch.qos.logback:logback-classic:1.4.11")
+
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,9 +24,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
-    implementation("org.postgresql:postgresql")
     implementation("org.springframework.data:spring-data-mongodb:4.3.3")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,15 +19,13 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     implementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
-    implementation("org.springframework.data:spring-data-mongodb:4.3.3")
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
@@ -1,6 +1,11 @@
 package org.team_leg3nd.tarae.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.ExpenseRequestDto
@@ -11,14 +16,26 @@ import org.team_leg3nd.tarae.entity.Member
 import org.team_leg3nd.tarae.service.ExpenseService
 import org.team_leg3nd.tarae.service.MemberService
 
-@RestController
+@Tag(name = "Expense API", description = "Operations related to Expenses")
 @RequestMapping("/api/expenses")
+@RestController
 class ExpenseController(
     private val expenseService: ExpenseService,
     private val memberService: MemberService
 ) {
 
-    @Operation(summary = "create expense", description = "create expense")
+    @Operation(
+        summary = "create expense",
+        description = "create expense",
+        requestBody = RequestBody(
+            description = "Expense creation details",
+            required = true
+        ),
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no member", content = [Content(examples = [ExampleObject(name = "MemberNotFound", value = "Member not found", description = "No member has a matching ID")])])
+        ]
+    )
     @PostMapping
     fun createExpense(@RequestBody expenseRequestDto: ExpenseRequestDto): ResponseEntity<ExpenseResponseDto> {
         val expense = expenseService.createExpense(expenseRequestDto.toExpense())
@@ -26,7 +43,14 @@ class ExpenseController(
         return ResponseEntity.ok(expense.toResponseDto())
     }
 
-    @Operation(summary = "read expense", description = "read expense")
+    @Operation(
+        summary = "read expense",
+        description = "read expense",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no expense", content = [Content(examples = [ExampleObject(name = "ExpenseNotFound", value = "Expense not found", description = "No Expense has a matching ID")])])
+        ]
+    )
     @GetMapping("/id/{id}")
     fun getExpense(@PathVariable id: String): ResponseEntity<ExpenseResponseDto> {
         val expense = expenseService.getExpense(id)
@@ -34,7 +58,18 @@ class ExpenseController(
         return ResponseEntity.ok(expense.toResponseDto())
     }
 
-    @Operation(summary = "update expense", description = "It is updated with values sent to the request body")
+    @Operation(
+        summary = "update expense",
+        description = "It is updated with values sent to the request body",
+        requestBody = RequestBody(
+            description = "Expense updating details",
+            required = true
+        ),
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no expense or member", content = [Content(examples = [ExampleObject(name = "ExpenseNotFound", value = "Expense not found", description = "No Expense has a matching ID"), ExampleObject(name = "MemberNotFound", value = "Member not found", description = "No member has a matching ID")])])
+        ]
+    )
     @PutMapping("/id/{id}")
     fun updateExpense(
         @PathVariable id: String,
@@ -45,7 +80,14 @@ class ExpenseController(
         return ResponseEntity.ok(updatedExpense.toResponseDto())
     }
 
-    @Operation(summary = "delete expense", description = "delete expense")
+    @Operation(
+        summary = "delete expense",
+        description = "delete expense",
+        responses = [
+            ApiResponse(responseCode = "204", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no expense", content = [Content(examples = [ExampleObject(name = "ExpenseNotFound", value = "Expense not found", description = "No Expense has a matching ID")])])
+        ]
+    )
     @DeleteMapping("/id/{id}")
     fun deleteExpense(@PathVariable id: String): ResponseEntity<Void> {
         expenseService.deleteExpense(id)
@@ -53,7 +95,13 @@ class ExpenseController(
         return ResponseEntity.noContent().build()
     }
 
-    @Operation(summary = "read all expense", description = "read all expense")
+    @Operation(
+        summary = "read all expense",
+        description = "read all expense",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation")
+        ]
+    )
     @GetMapping
     fun getAllExpenses(): ResponseEntity<List<ExpenseResponseDto>> {
         val allExpenses = expenseService.getAllExpenses()

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
@@ -1,5 +1,6 @@
 package org.team_leg3nd.tarae.controller
 
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.ExpenseRequestDto
@@ -17,6 +18,7 @@ class ExpenseController(
     private val memberService: MemberService
 ) {
 
+    @Operation(summary = "create expense", description = "create expense")
     @PostMapping
     fun createExpense(@RequestBody expenseRequestDto: ExpenseRequestDto): ResponseEntity<ExpenseResponseDto> {
         val expense = expenseService.createExpense(expenseRequestDto.toExpense())
@@ -24,6 +26,7 @@ class ExpenseController(
         return ResponseEntity.ok(expense.toResponseDto())
     }
 
+    @Operation(summary = "read expense", description = "read expense")
     @GetMapping("/id/{id}")
     fun getExpense(@PathVariable id: String): ResponseEntity<ExpenseResponseDto> {
         val expense = expenseService.getExpense(id)
@@ -31,6 +34,7 @@ class ExpenseController(
         return ResponseEntity.ok(expense.toResponseDto())
     }
 
+    @Operation(summary = "update expense", description = "It is updated with values sent to the request body")
     @PutMapping("/id/{id}")
     fun updateExpense(
         @PathVariable id: String,
@@ -41,6 +45,7 @@ class ExpenseController(
         return ResponseEntity.ok(updatedExpense.toResponseDto())
     }
 
+    @Operation(summary = "delete expense", description = "delete expense")
     @DeleteMapping("/id/{id}")
     fun deleteExpense(@PathVariable id: String): ResponseEntity<Void> {
         expenseService.deleteExpense(id)
@@ -48,7 +53,7 @@ class ExpenseController(
         return ResponseEntity.noContent().build()
     }
 
-    // 전체 지출 조회
+    @Operation(summary = "read all expense", description = "read all expense")
     @GetMapping
     fun getAllExpenses(): ResponseEntity<List<ExpenseResponseDto>> {
         val allExpenses = expenseService.getAllExpenses()

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
@@ -17,20 +17,20 @@ class ExpenseController(private val expenseService: ExpenseService) {
         return ResponseEntity.ok(expense.toResponseDto())
     }
 
-    @GetMapping("/{id}")
-    fun getExpense(@PathVariable id: String): ResponseEntity<ExpenseResponseDto> {
+    @GetMapping("/id")
+    fun getExpense(@RequestParam id: String): ResponseEntity<ExpenseResponseDto> {
         val expense = expenseService.getExpense(id)
         return ResponseEntity.ok(expense.toResponseDto())
     }
 
-    @PutMapping("/{id}")
-    fun updateExpense(@PathVariable id: String, @RequestBody expenseRequestDto: ExpenseRequestDto): ResponseEntity<ExpenseResponseDto> {
+    @PutMapping("/id")
+    fun updateExpense(@RequestParam id: String, @RequestBody expenseRequestDto: ExpenseRequestDto): ResponseEntity<ExpenseResponseDto> {
         val updatedExpense = expenseService.updateExpense(id, expenseRequestDto)
         return ResponseEntity.ok(updatedExpense.toResponseDto())
     }
 
-    @DeleteMapping("/{id}")
-    fun deleteExpense(@PathVariable id: String): ResponseEntity<Void> {
+    @DeleteMapping("/id")
+    fun deleteExpense(@RequestParam id: String): ResponseEntity<Void> {
         expenseService.deleteExpense(id)
         return ResponseEntity.noContent().build()
     }
@@ -43,7 +43,7 @@ class ExpenseController(private val expenseService: ExpenseService) {
 
     // Expense.paidBy로 지출 조회
     @GetMapping("/paidBy")
-    fun getExpenseByPaidBy(@RequestBody paidBy: String): List<Expense> {
+    fun getExpenseByPaidBy(@RequestParam paidBy: String): List<Expense> {
         return expenseService.getExpenseByPaidBy(paidBy)
     }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
@@ -1,0 +1,57 @@
+package org.team_leg3nd.tarae.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.team_leg3nd.tarae.controller.dto.request.ExpenseRequestDto
+import org.team_leg3nd.tarae.controller.dto.response.ExpenseResponseDto
+import org.team_leg3nd.tarae.entity.Expense
+import org.team_leg3nd.tarae.service.ExpenseService
+
+@RestController
+@RequestMapping("/api/expenses")
+class ExpenseController(private val expenseService: ExpenseService) {
+
+    @PostMapping
+    fun createExpense(@RequestBody expenseRequestDto: ExpenseRequestDto): ResponseEntity<ExpenseResponseDto> {
+        val expense = expenseService.createExpense(expenseRequestDto)
+        return ResponseEntity.ok(expense.toResponseDto())
+    }
+
+    @GetMapping("/{id}")
+    fun getExpense(@PathVariable id: String): ResponseEntity<ExpenseResponseDto> {
+        val expense = expenseService.getExpense(id)
+        return ResponseEntity.ok(expense.toResponseDto())
+    }
+
+    @PutMapping("/{id}")
+    fun updateExpense(@PathVariable id: String, @RequestBody expenseRequestDto: ExpenseRequestDto): ResponseEntity<ExpenseResponseDto> {
+        val updatedExpense = expenseService.updateExpense(id, expenseRequestDto)
+        return ResponseEntity.ok(updatedExpense.toResponseDto())
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteExpense(@PathVariable id: String): ResponseEntity<Void> {
+        expenseService.deleteExpense(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    // 전체 지출 조회
+    @GetMapping
+    fun getAllExpenses(): List<Expense> {
+        return expenseService.getAllExpenses()
+    }
+
+    // Expense.paidBy로 지출 조회
+    @GetMapping("/paidBy")
+    fun getExpenseByPaidBy(@RequestBody paidBy: String): List<Expense> {
+        return expenseService.getExpenseByPaidBy(paidBy)
+    }
+
+    fun Expense.toResponseDto(): ExpenseResponseDto {
+        val paidByNames = this.paidBy.map { it.name }
+        val sharedWithNames = this.sharedWith?.map { it.name }
+        return ExpenseResponseDto(id = this.id ?: "", description = this.description, amount = this.amount, paidBy = paidByNames, sharedWith = sharedWithNames)
+    }
+}
+
+

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
@@ -56,14 +56,6 @@ class ExpenseController(
         return ResponseEntity.ok(allExpenses.map { expense: Expense -> expense.toResponseDto() })
     }
 
-    // Expense.paidBy로 지출 조회
-    @GetMapping("/paidBy/{paidBy}")
-    fun getExpenseByPaidBy(@PathVariable paidBy: String): ResponseEntity<List<ExpenseResponseDto>> {
-        val expenseByPaidBy = expenseService.getExpenseByPaidBy(paidBy)
-
-        return ResponseEntity.ok(expenseByPaidBy.map { expense: Expense -> expense.toResponseDto() })
-    }
-
     fun Expense.toResponseDto(): ExpenseResponseDto {
         return ExpenseResponseDto(
             id = this.id ?: "",

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
@@ -17,20 +17,20 @@ class ExpenseController(private val expenseService: ExpenseService) {
         return ResponseEntity.ok(expense.toResponseDto())
     }
 
-    @GetMapping("/id")
-    fun getExpense(@RequestParam id: String): ResponseEntity<ExpenseResponseDto> {
+    @GetMapping("/id/{id}")
+    fun getExpense(@PathVariable id: String): ResponseEntity<ExpenseResponseDto> {
         val expense = expenseService.getExpense(id)
         return ResponseEntity.ok(expense.toResponseDto())
     }
 
-    @PutMapping("/id")
-    fun updateExpense(@RequestParam id: String, @RequestBody expenseRequestDto: ExpenseRequestDto): ResponseEntity<ExpenseResponseDto> {
+    @PutMapping("/id/{id}")
+    fun updateExpense(@PathVariable id: String, @RequestBody expenseRequestDto: ExpenseRequestDto): ResponseEntity<ExpenseResponseDto> {
         val updatedExpense = expenseService.updateExpense(id, expenseRequestDto)
         return ResponseEntity.ok(updatedExpense.toResponseDto())
     }
 
-    @DeleteMapping("/id")
-    fun deleteExpense(@RequestParam id: String): ResponseEntity<Void> {
+    @DeleteMapping("/id/{id}")
+    fun deleteExpense(@PathVariable id: String): ResponseEntity<Void> {
         expenseService.deleteExpense(id)
         return ResponseEntity.noContent().build()
     }
@@ -42,8 +42,8 @@ class ExpenseController(private val expenseService: ExpenseService) {
     }
 
     // Expense.paidBy로 지출 조회
-    @GetMapping("/paidBy")
-    fun getExpenseByPaidBy(@RequestParam paidBy: String): List<Expense> {
+    @GetMapping("/paidBy/{paidBy}")
+    fun getExpenseByPaidBy(@PathVariable paidBy: String): List<Expense> {
         return expenseService.getExpenseByPaidBy(paidBy)
     }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/ExpenseController.kt
@@ -73,6 +73,9 @@ class ExpenseController(
             paidBy = this.paidBy.map { id: String ->
                 memberService.getMember(id)
             },
+            sharedWith = this.sharedWith?.map { id: String ->
+                memberService.getMember(id)
+            }
         )
     }
 }

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
@@ -5,16 +5,23 @@ import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.GroupRequestDto
 import org.team_leg3nd.tarae.controller.dto.response.GroupResponseDto
 import org.team_leg3nd.tarae.entity.Group
+import org.team_leg3nd.tarae.entity.Member
+import org.team_leg3nd.tarae.service.ExpenseService
 import org.team_leg3nd.tarae.service.GroupService
+import org.team_leg3nd.tarae.service.MemberService
 
 @RestController
 @RequestMapping("/api/groups")
-class GroupController(private val groupService: GroupService) {
+class GroupController(
+    private val groupService: GroupService,
+    private val memberService: MemberService,
+    private val expenseService: ExpenseService
+) {
 
     // 그룹 생성
     @PostMapping
     fun createGroup(@RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
-        val group = groupService.createGroup(groupRequestDto)
+        val group = groupService.createGroup(groupRequestDto.toGroup())
         return ResponseEntity.ok(group.toResponseDto())
     }
 
@@ -27,8 +34,11 @@ class GroupController(private val groupService: GroupService) {
 
     // 그룹 수정
     @PutMapping("/id/{id}")
-    fun updateGroup(@PathVariable id: String, @RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
-        val updatedGroup = groupService.updateGroup(id, groupRequestDto)
+    fun updateGroup(
+        @PathVariable id: String,
+        @RequestBody groupRequestDto: GroupRequestDto
+    ): ResponseEntity<GroupResponseDto> {
+        val updatedGroup = groupService.updateGroup(id, groupRequestDto.toGroup())
         return ResponseEntity.ok(updatedGroup.toResponseDto())
     }
 
@@ -55,6 +65,18 @@ class GroupController(private val groupService: GroupService) {
         val memberNames = this.members?.map { it.name }
         val expenseIds = this.expenses?.map { it.id!! }
         return GroupResponseDto(id = this.id ?: "", name = this.name, members = memberNames, expenses = expenseIds)
+    }
+
+    fun GroupRequestDto.toGroup(): Group {
+        return Group(
+            name = this.name,
+            members = this.members?.map { id: String ->
+                memberService.getMember(id)
+            },
+            expenses = this.expenses?.map { id: String ->
+                expenseService.getExpense(id)
+            }
+        )
     }
 }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
@@ -19,21 +19,21 @@ class GroupController(private val groupService: GroupService) {
     }
 
     // 그룹 조회
-    @GetMapping("/{id}")
+    @GetMapping("/id")
     fun getGroup(@PathVariable id: String): ResponseEntity<GroupResponseDto> {
         val group = groupService.getGroup(id)
         return ResponseEntity.ok(group.toResponseDto())
     }
 
     // 그룹 수정
-    @PutMapping("/{id}")
+    @PutMapping("/id")
     fun updateGroup(@PathVariable id: String, @RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
         val updatedGroup = groupService.updateGroup(id, groupRequestDto)
         return ResponseEntity.ok(updatedGroup.toResponseDto())
     }
 
     // 그룹 삭제
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/id")
     fun deleteGroup(@PathVariable id: String): ResponseEntity<Void> {
         groupService.deleteGroup(id)
         return ResponseEntity.noContent().build()
@@ -46,8 +46,8 @@ class GroupController(private val groupService: GroupService) {
     }
 
     // Group.name으로 그룹 조회
-    @GetMapping("/name/{name}")
-    fun getGroupByName(@PathVariable name: String): Group? {
+    @GetMapping("/name")
+    fun getGroupByName(@RequestParam name: String): Group? {
         return groupService.getGroupByName(name)
     }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
@@ -3,7 +3,10 @@ package org.team_leg3nd.tarae.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.GroupRequestDto
+import org.team_leg3nd.tarae.controller.dto.response.ExpenseProjectionResponseDto
 import org.team_leg3nd.tarae.controller.dto.response.GroupResponseDto
+import org.team_leg3nd.tarae.controller.dto.response.MemberProjectionResponseDto
+import org.team_leg3nd.tarae.entity.Expense
 import org.team_leg3nd.tarae.entity.Group
 import org.team_leg3nd.tarae.entity.Member
 import org.team_leg3nd.tarae.service.ExpenseService
@@ -22,6 +25,7 @@ class GroupController(
     @PostMapping
     fun createGroup(@RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
         val group = groupService.createGroup(groupRequestDto.toGroup())
+
         return ResponseEntity.ok(group.toResponseDto())
     }
 
@@ -29,6 +33,7 @@ class GroupController(
     @GetMapping("/id/{id}")
     fun getGroup(@PathVariable id: String): ResponseEntity<GroupResponseDto> {
         val group = groupService.getGroup(id)
+
         return ResponseEntity.ok(group.toResponseDto())
     }
 
@@ -39,6 +44,7 @@ class GroupController(
         @RequestBody groupRequestDto: GroupRequestDto
     ): ResponseEntity<GroupResponseDto> {
         val updatedGroup = groupService.updateGroup(id, groupRequestDto.toGroup())
+
         return ResponseEntity.ok(updatedGroup.toResponseDto())
     }
 
@@ -46,25 +52,44 @@ class GroupController(
     @DeleteMapping("/id/{id}")
     fun deleteGroup(@PathVariable id: String): ResponseEntity<Void> {
         groupService.deleteGroup(id)
+
         return ResponseEntity.noContent().build()
     }
 
     // 전체 그룹 조회
     @GetMapping
-    fun getAllGroups(): List<Group> {
-        return groupService.getAllGroups()
+    fun getAllGroups(): ResponseEntity<List<GroupResponseDto>> {
+        val allGroups = groupService.getAllGroups()
+
+        return ResponseEntity.ok(allGroups.map { group: Group -> group.toResponseDto() })
     }
 
     // Group.name으로 그룹 조회
     @GetMapping("/name/{name}")
-    fun getGroupByName(@PathVariable name: String): Group? {
-        return groupService.getGroupByName(name)
+    fun getGroupByName(@PathVariable name: String): ResponseEntity<GroupResponseDto> {
+        val groupByName = groupService.getGroupByName(name)
+
+        return ResponseEntity.ok(groupByName?.toResponseDto())
     }
 
     fun Group.toResponseDto(): GroupResponseDto {
-        val memberNames = this.members?.map { it.name }
-        val expenseIds = this.expenses?.map { it.id!! }
-        return GroupResponseDto(id = this.id ?: "", name = this.name, members = memberNames, expenses = expenseIds)
+        return GroupResponseDto(
+            id = this.id ?: "",
+            name = this.name,
+            members = this.members?.map { member: Member ->
+                MemberProjectionResponseDto(
+                    id = member.id!!,
+                    name = member.name
+                )
+            },
+            expenses = this.expenses?.map { expense: Expense ->
+                ExpenseProjectionResponseDto(
+                    id = expense.id!!,
+                    description = expense.description,
+                    amount = expense.amount
+                )
+            }
+        )
     }
 
     fun GroupRequestDto.toGroup(): Group {

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
@@ -1,0 +1,62 @@
+package org.team_leg3nd.tarae.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.team_leg3nd.tarae.controller.dto.request.GroupRequestDto
+import org.team_leg3nd.tarae.controller.dto.response.GroupResponseDto
+import org.team_leg3nd.tarae.entity.Group
+import org.team_leg3nd.tarae.service.GroupService
+
+@RestController
+@RequestMapping("/api/groups")
+class GroupController(private val groupService: GroupService) {
+
+    // 그룹 생성
+    @PostMapping
+    fun createGroup(@RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
+        val group = groupService.createGroup(groupRequestDto)
+        return ResponseEntity.ok(group.toResponseDto())
+    }
+
+    // 그룹 조회
+    @GetMapping("/{id}")
+    fun getGroup(@PathVariable id: String): ResponseEntity<GroupResponseDto> {
+        val group = groupService.getGroup(id)
+        return ResponseEntity.ok(group.toResponseDto())
+    }
+
+    // 그룹 수정
+    @PutMapping("/{id}")
+    fun updateGroup(@PathVariable id: String, @RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
+        val updatedGroup = groupService.updateGroup(id, groupRequestDto)
+        return ResponseEntity.ok(updatedGroup.toResponseDto())
+    }
+
+    // 그룹 삭제
+    @DeleteMapping("/{id}")
+    fun deleteGroup(@PathVariable id: String): ResponseEntity<Void> {
+        groupService.deleteGroup(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    // 전체 그룹 조회
+    @GetMapping
+    fun getAllGroups(): List<Group> {
+        return groupService.getAllGroups()
+    }
+
+    // Group.name으로 그룹 조회
+    @GetMapping("/name/{name}")
+    fun getGroupByName(@PathVariable name: String): Group? {
+        return groupService.getGroupByName(name)
+    }
+
+    fun Group.toResponseDto(): GroupResponseDto {
+        val memberNames = this.members?.map { it.name }
+        val expenseIds = this.expenses?.map { it.id!! }
+        return GroupResponseDto(id = this.id ?: "", name = this.name, members = memberNames, expenses = expenseIds)
+    }
+}
+
+
+

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
@@ -1,5 +1,6 @@
 package org.team_leg3nd.tarae.controller
 
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.GroupRequestDto
@@ -21,7 +22,7 @@ class GroupController(
     private val expenseService: ExpenseService
 ) {
 
-    // 그룹 생성
+    @Operation(summary = "create group", description = "create group")
     @PostMapping
     fun createGroup(@RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
         val group = groupService.createGroup(groupRequestDto.toGroup())
@@ -29,7 +30,7 @@ class GroupController(
         return ResponseEntity.ok(group.toResponseDto())
     }
 
-    // 그룹 조회
+    @Operation(summary = "read group", description = "read group")
     @GetMapping("/id/{id}")
     fun getGroup(@PathVariable id: String): ResponseEntity<GroupResponseDto> {
         val group = groupService.getGroup(id)
@@ -37,7 +38,7 @@ class GroupController(
         return ResponseEntity.ok(group.toResponseDto())
     }
 
-    // 그룹 수정
+    @Operation(summary = "update group", description = "It is updated with values sent to the request body")
     @PutMapping("/id/{id}")
     fun updateGroup(
         @PathVariable id: String,
@@ -48,7 +49,7 @@ class GroupController(
         return ResponseEntity.ok(updatedGroup.toResponseDto())
     }
 
-    // 그룹 삭제
+    @Operation(summary = "delete group", description = "delete group")
     @DeleteMapping("/id/{id}")
     fun deleteGroup(@PathVariable id: String): ResponseEntity<Void> {
         groupService.deleteGroup(id)
@@ -56,7 +57,7 @@ class GroupController(
         return ResponseEntity.noContent().build()
     }
 
-    // 전체 그룹 조회
+    @Operation(summary = "read all group", description = "read all group")
     @GetMapping
     fun getAllGroups(): ResponseEntity<List<GroupResponseDto>> {
         val allGroups = groupService.getAllGroups()

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
@@ -19,21 +19,21 @@ class GroupController(private val groupService: GroupService) {
     }
 
     // 그룹 조회
-    @GetMapping("/id")
+    @GetMapping("/id/{id}")
     fun getGroup(@PathVariable id: String): ResponseEntity<GroupResponseDto> {
         val group = groupService.getGroup(id)
         return ResponseEntity.ok(group.toResponseDto())
     }
 
     // 그룹 수정
-    @PutMapping("/id")
+    @PutMapping("/id/{id}")
     fun updateGroup(@PathVariable id: String, @RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
         val updatedGroup = groupService.updateGroup(id, groupRequestDto)
         return ResponseEntity.ok(updatedGroup.toResponseDto())
     }
 
     // 그룹 삭제
-    @DeleteMapping("/id")
+    @DeleteMapping("/id/{id}")
     fun deleteGroup(@PathVariable id: String): ResponseEntity<Void> {
         groupService.deleteGroup(id)
         return ResponseEntity.noContent().build()
@@ -46,8 +46,8 @@ class GroupController(private val groupService: GroupService) {
     }
 
     // Group.name으로 그룹 조회
-    @GetMapping("/name")
-    fun getGroupByName(@RequestParam name: String): Group? {
+    @GetMapping("/name/{name}")
+    fun getGroupByName(@PathVariable name: String): Group? {
         return groupService.getGroupByName(name)
     }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/GroupController.kt
@@ -1,6 +1,11 @@
 package org.team_leg3nd.tarae.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.GroupRequestDto
@@ -14,15 +19,27 @@ import org.team_leg3nd.tarae.service.ExpenseService
 import org.team_leg3nd.tarae.service.GroupService
 import org.team_leg3nd.tarae.service.MemberService
 
-@RestController
+@Tag(name = "Group API", description = "Operations related to Groups")
 @RequestMapping("/api/groups")
+@RestController
 class GroupController(
     private val groupService: GroupService,
     private val memberService: MemberService,
     private val expenseService: ExpenseService
 ) {
 
-    @Operation(summary = "create group", description = "create group")
+    @Operation(
+        summary = "create group",
+        description = "create group",
+        requestBody = RequestBody(
+            description = "Group creation details",
+            required = true
+        ),
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no expense or member", content = [Content(examples = [ExampleObject(name = "ExpenseNotFound", value = "Expense not found", description = "No Expense has a matching ID"), ExampleObject(name = "MemberNotFound", value = "Member not found", description = "No member has a matching ID")])])
+        ]
+    )
     @PostMapping
     fun createGroup(@RequestBody groupRequestDto: GroupRequestDto): ResponseEntity<GroupResponseDto> {
         val group = groupService.createGroup(groupRequestDto.toGroup())
@@ -30,7 +47,14 @@ class GroupController(
         return ResponseEntity.ok(group.toResponseDto())
     }
 
-    @Operation(summary = "read group", description = "read group")
+    @Operation(
+        summary = "read group",
+        description = "read group",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no group", content = [Content(examples = [ExampleObject(name = "GroupNotFound", value = "Group not found", description = "No Group has a matching ID")])])
+        ]
+    )
     @GetMapping("/id/{id}")
     fun getGroup(@PathVariable id: String): ResponseEntity<GroupResponseDto> {
         val group = groupService.getGroup(id)
@@ -38,7 +62,18 @@ class GroupController(
         return ResponseEntity.ok(group.toResponseDto())
     }
 
-    @Operation(summary = "update group", description = "It is updated with values sent to the request body")
+    @Operation(
+        summary = "update group",
+        description = "It is updated with values sent to the request body",
+        requestBody = RequestBody(
+            description = "Group updating details",
+            required = true
+        ),
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no expense or member", content = [Content(examples = [ExampleObject(name = "ExpenseNotFound", value = "Expense not found", description = "No Expense has a matching ID"), ExampleObject(name = "MemberNotFound", value = "Member not found", description = "No member has a matching ID")])])
+        ]
+    )
     @PutMapping("/id/{id}")
     fun updateGroup(
         @PathVariable id: String,
@@ -49,7 +84,14 @@ class GroupController(
         return ResponseEntity.ok(updatedGroup.toResponseDto())
     }
 
-    @Operation(summary = "delete group", description = "delete group")
+    @Operation(
+        summary = "delete group",
+        description = "delete group",
+        responses = [
+            ApiResponse(responseCode = "204", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no group", content = [Content(examples = [ExampleObject(name = "GroupNotFound", value = "Group not found", description = "No Group has a matching ID")])])
+        ]
+    )
     @DeleteMapping("/id/{id}")
     fun deleteGroup(@PathVariable id: String): ResponseEntity<Void> {
         groupService.deleteGroup(id)
@@ -57,7 +99,13 @@ class GroupController(
         return ResponseEntity.noContent().build()
     }
 
-    @Operation(summary = "read all group", description = "read all group")
+    @Operation(
+        summary = "read all group",
+        description = "read all group",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation")
+        ]
+    )
     @GetMapping
     fun getAllGroups(): ResponseEntity<List<GroupResponseDto>> {
         val allGroups = groupService.getAllGroups()
@@ -65,7 +113,13 @@ class GroupController(
         return ResponseEntity.ok(allGroups.map { group: Group -> group.toResponseDto() })
     }
 
-    // Group.name으로 그룹 조회
+    @Operation(
+        summary = "read group by name",
+        description = "read group by name",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation")
+        ]
+    )
     @GetMapping("/name/{name}")
     fun getGroupByName(@PathVariable name: String): ResponseEntity<GroupResponseDto> {
         val groupByName = groupService.getGroupByName(name)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
@@ -3,12 +3,12 @@ package org.team_leg3nd.tarae.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.MemberRequestDto
+import org.team_leg3nd.tarae.controller.dto.response.ExpenseProjectionResponseDto
 import org.team_leg3nd.tarae.controller.dto.response.MemberResponseDto
 import org.team_leg3nd.tarae.entity.Expense
 import org.team_leg3nd.tarae.entity.Member
 import org.team_leg3nd.tarae.service.ExpenseService
 import org.team_leg3nd.tarae.service.MemberService
-import kotlin.math.E
 
 @RestController
 @RequestMapping("/api/members")
@@ -21,6 +21,7 @@ class MemberController(
     @PostMapping
     fun createMember(@RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
         val member = memberService.createMember(memberRequestDto.toMember())
+
         return ResponseEntity.ok(member.toResponseDto())
     }
 
@@ -28,6 +29,7 @@ class MemberController(
     @GetMapping("/id/{id}")
     fun getMember(@PathVariable id: String): ResponseEntity<MemberResponseDto> {
         val member = memberService.getMember(id)
+
         return ResponseEntity.ok(member.toResponseDto())
     }
 
@@ -38,6 +40,7 @@ class MemberController(
         @RequestBody memberRequestDto: MemberRequestDto
     ): ResponseEntity<MemberResponseDto> {
         val updatedMember = memberService.updateMember(id, memberRequestDto.toMember())
+
         return ResponseEntity.ok(updatedMember.toResponseDto())
     }
 
@@ -45,24 +48,38 @@ class MemberController(
     @DeleteMapping("/id/{id}")
     fun deleteMember(@PathVariable id: String): ResponseEntity<Void> {
         memberService.deleteMember(id)
+
         return ResponseEntity.noContent().build()
     }
 
     // 전체 멤버 조회
     @GetMapping
-    fun getAllMembers(): List<Member> {
-        return memberService.getAllMembers()
+    fun getAllMembers(): ResponseEntity<List<MemberResponseDto>> {
+        val allMembers = memberService.getAllMembers()
+
+        return ResponseEntity.ok(allMembers.map { member: Member -> member.toResponseDto() })
     }
 
     // Member.name으로 멤버 조회
     @GetMapping("/name/{name}")
-    fun getMemberByName(@PathVariable name: String): Member? {
-        return memberService.getMemberByName(name)
+    fun getMemberByName(@PathVariable name: String): ResponseEntity<MemberResponseDto> {
+        val memberByName = memberService.getMemberByName(name)
+
+        return ResponseEntity.ok(memberByName?.toResponseDto())
     }
 
     fun Member.toResponseDto(): MemberResponseDto {
-        val paidExpenseIds = this.paidExpenses?.map { it.id!! }
-        return MemberResponseDto(id = this.id ?: "", name = this.name, paidExpenses = paidExpenseIds)
+        return MemberResponseDto(
+            id = this.id ?: "",
+            name = this.name,
+            paidExpenses = this.paidExpenses?.map { expense: Expense ->
+                ExpenseProjectionResponseDto(
+                    id = expense.id!!,
+                    description = expense.description,
+                    amount = expense.amount
+                )
+            }
+        )
     }
 
     fun MemberRequestDto.toMember(): Member {

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
@@ -4,17 +4,23 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.MemberRequestDto
 import org.team_leg3nd.tarae.controller.dto.response.MemberResponseDto
+import org.team_leg3nd.tarae.entity.Expense
 import org.team_leg3nd.tarae.entity.Member
+import org.team_leg3nd.tarae.service.ExpenseService
 import org.team_leg3nd.tarae.service.MemberService
+import kotlin.math.E
 
 @RestController
 @RequestMapping("/api/members")
-class MemberController(private val memberService: MemberService) {
+class MemberController(
+    private val memberService: MemberService,
+    private val expenseService: ExpenseService
+) {
 
     // 멤버 생성
     @PostMapping
     fun createMember(@RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
-        val member = memberService.createMember(memberRequestDto)
+        val member = memberService.createMember(memberRequestDto.toMember())
         return ResponseEntity.ok(member.toResponseDto())
     }
 
@@ -27,8 +33,11 @@ class MemberController(private val memberService: MemberService) {
 
     // 멤버 수정
     @PutMapping("/id/{id}")
-    fun updateMember(@PathVariable id: String, @RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
-        val updatedMember = memberService.updateMember(id, memberRequestDto)
+    fun updateMember(
+        @PathVariable id: String,
+        @RequestBody memberRequestDto: MemberRequestDto
+    ): ResponseEntity<MemberResponseDto> {
+        val updatedMember = memberService.updateMember(id, memberRequestDto.toMember())
         return ResponseEntity.ok(updatedMember.toResponseDto())
     }
 
@@ -54,6 +63,15 @@ class MemberController(private val memberService: MemberService) {
     fun Member.toResponseDto(): MemberResponseDto {
         val paidExpenseIds = this.paidExpenses?.map { it.id!! }
         return MemberResponseDto(id = this.id ?: "", name = this.name, paidExpenses = paidExpenseIds)
+    }
+
+    fun MemberRequestDto.toMember(): Member {
+        return Member(
+            name = this.name,
+            paidExpenses = this.paidExpenses?.map { id: String ->
+                expenseService.getExpense(id)
+            }
+        )
     }
 }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
@@ -1,5 +1,6 @@
 package org.team_leg3nd.tarae.controller
 
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.MemberRequestDto
@@ -17,7 +18,7 @@ class MemberController(
     private val expenseService: ExpenseService
 ) {
 
-    // 멤버 생성
+    @Operation(summary = "create member", description = "create member")
     @PostMapping
     fun createMember(@RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
         val member = memberService.createMember(memberRequestDto.toMember())
@@ -25,7 +26,7 @@ class MemberController(
         return ResponseEntity.ok(member.toResponseDto())
     }
 
-    // 멤버 조회
+    @Operation(summary = "read member", description = "read member")
     @GetMapping("/id/{id}")
     fun getMember(@PathVariable id: String): ResponseEntity<MemberResponseDto> {
         val member = memberService.getMember(id)
@@ -33,7 +34,7 @@ class MemberController(
         return ResponseEntity.ok(member.toResponseDto())
     }
 
-    // 멤버 수정
+    @Operation(summary = "update member", description = "It is updated with values sent to the request body")
     @PutMapping("/id/{id}")
     fun updateMember(
         @PathVariable id: String,
@@ -44,7 +45,7 @@ class MemberController(
         return ResponseEntity.ok(updatedMember.toResponseDto())
     }
 
-    // 멤버 삭제
+    @Operation(summary = "delete member", description = "delete member")
     @DeleteMapping("/id/{id}")
     fun deleteMember(@PathVariable id: String): ResponseEntity<Void> {
         memberService.deleteMember(id)
@@ -52,7 +53,7 @@ class MemberController(
         return ResponseEntity.noContent().build()
     }
 
-    // 전체 멤버 조회
+    @Operation(summary = "read all member", description = "read all member")
     @GetMapping
     fun getAllMembers(): ResponseEntity<List<MemberResponseDto>> {
         val allMembers = memberService.getAllMembers()
@@ -60,7 +61,7 @@ class MemberController(
         return ResponseEntity.ok(allMembers.map { member: Member -> member.toResponseDto() })
     }
 
-    // Member.name으로 멤버 조회
+    @Operation(summary = "read member by name", description = "read member by name")
     @GetMapping("/name/{name}")
     fun getMemberByName(@PathVariable name: String): ResponseEntity<MemberResponseDto> {
         val memberByName = memberService.getMemberByName(name)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
@@ -19,22 +19,22 @@ class MemberController(private val memberService: MemberService) {
     }
 
     // 멤버 조회
-    @GetMapping("/id")
-    fun getMember(@RequestParam id: String): ResponseEntity<MemberResponseDto> {
+    @GetMapping("/id/{id}")
+    fun getMember(@PathVariable id: String): ResponseEntity<MemberResponseDto> {
         val member = memberService.getMember(id)
         return ResponseEntity.ok(member.toResponseDto())
     }
 
     // 멤버 수정
-    @PutMapping("/id")
-    fun updateMember(@RequestParam id: String, @RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
+    @PutMapping("/id/{id}")
+    fun updateMember(@PathVariable id: String, @RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
         val updatedMember = memberService.updateMember(id, memberRequestDto)
         return ResponseEntity.ok(updatedMember.toResponseDto())
     }
 
     // 멤버 삭제
-    @DeleteMapping("/id")
-    fun deleteMember(@RequestParam id: String): ResponseEntity<Void> {
+    @DeleteMapping("/id/{id}")
+    fun deleteMember(@PathVariable id: String): ResponseEntity<Void> {
         memberService.deleteMember(id)
         return ResponseEntity.noContent().build()
     }
@@ -46,8 +46,8 @@ class MemberController(private val memberService: MemberService) {
     }
 
     // Member.name으로 멤버 조회
-    @GetMapping("/name")
-    fun getMemberByName(@RequestParam name: String): Member? {
+    @GetMapping("/name/{name}")
+    fun getMemberByName(@PathVariable name: String): Member? {
         return memberService.getMemberByName(name)
     }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
@@ -1,0 +1,59 @@
+package org.team_leg3nd.tarae.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.team_leg3nd.tarae.controller.dto.request.MemberRequestDto
+import org.team_leg3nd.tarae.controller.dto.response.MemberResponseDto
+import org.team_leg3nd.tarae.entity.Member
+import org.team_leg3nd.tarae.service.MemberService
+
+@RestController
+@RequestMapping("/api/members")
+class MemberController(private val memberService: MemberService) {
+
+    // 멤버 생성
+    @PostMapping
+    fun createMember(@RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
+        val member = memberService.createMember(memberRequestDto)
+        return ResponseEntity.ok(member.toResponseDto())
+    }
+
+    // 멤버 조회
+    @GetMapping("/id")
+    fun getMember(@RequestParam id: String): ResponseEntity<MemberResponseDto> {
+        val member = memberService.getMember(id)
+        return ResponseEntity.ok(member.toResponseDto())
+    }
+
+    // 멤버 수정
+    @PutMapping("/id")
+    fun updateMember(@RequestParam id: String, @RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
+        val updatedMember = memberService.updateMember(id, memberRequestDto)
+        return ResponseEntity.ok(updatedMember.toResponseDto())
+    }
+
+    // 멤버 삭제
+    @DeleteMapping("/id")
+    fun deleteMember(@RequestParam id: String): ResponseEntity<Void> {
+        memberService.deleteMember(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    // 전체 멤버 조회
+    @GetMapping
+    fun getAllMembers(): List<Member> {
+        return memberService.getAllMembers()
+    }
+
+    // Member.name으로 멤버 조회
+    @GetMapping("/name")
+    fun getMemberByName(@RequestParam name: String): Member? {
+        return memberService.getMemberByName(name)
+    }
+
+    fun Member.toResponseDto(): MemberResponseDto {
+        val paidExpenseIds = this.paidExpenses?.map { it.id!! }
+        return MemberResponseDto(id = this.id ?: "", name = this.name, paidExpenses = paidExpenseIds)
+    }
+}
+

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/MemberController.kt
@@ -1,6 +1,11 @@
 package org.team_leg3nd.tarae.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.team_leg3nd.tarae.controller.dto.request.MemberRequestDto
@@ -11,14 +16,26 @@ import org.team_leg3nd.tarae.entity.Member
 import org.team_leg3nd.tarae.service.ExpenseService
 import org.team_leg3nd.tarae.service.MemberService
 
-@RestController
+@Tag(name = "Member API", description = "Operations related to members")
 @RequestMapping("/api/members")
+@RestController
 class MemberController(
     private val memberService: MemberService,
     private val expenseService: ExpenseService
 ) {
 
-    @Operation(summary = "create member", description = "create member")
+    @Operation(
+        summary = "create member",
+        description = "create member",
+        requestBody = RequestBody(
+            description = "Member creation details",
+            required = true
+        ),
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no expense", content = [Content(examples = [ExampleObject(name = "ExpenseNotFound", value = "Expense not found", description = "No Expense has a matching ID")])])
+        ]
+    )
     @PostMapping
     fun createMember(@RequestBody memberRequestDto: MemberRequestDto): ResponseEntity<MemberResponseDto> {
         val member = memberService.createMember(memberRequestDto.toMember())
@@ -26,7 +43,14 @@ class MemberController(
         return ResponseEntity.ok(member.toResponseDto())
     }
 
-    @Operation(summary = "read member", description = "read member")
+    @Operation(
+        summary = "read member",
+        description = "read member",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no member", content = [Content(examples = [ExampleObject(name = "MemberNotFound", value = "Member not found", description = "No member has a matching ID")])])
+        ]
+    )
     @GetMapping("/id/{id}")
     fun getMember(@PathVariable id: String): ResponseEntity<MemberResponseDto> {
         val member = memberService.getMember(id)
@@ -34,7 +58,18 @@ class MemberController(
         return ResponseEntity.ok(member.toResponseDto())
     }
 
-    @Operation(summary = "update member", description = "It is updated with values sent to the request body")
+    @Operation(
+        summary = "update member",
+        description = "It is updated with values sent to the request body",
+        requestBody = RequestBody(
+            description = "Member updating details",
+            required = true
+        ),
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no expense or member", content = [Content(examples = [ExampleObject(name = "ExpenseNotFound", value = "Expense not found", description = "No Expense has a matching ID"), ExampleObject(name = "MemberNotFound", value = "Member not found", description = "No member has a matching ID")])])
+        ]
+    )
     @PutMapping("/id/{id}")
     fun updateMember(
         @PathVariable id: String,
@@ -45,7 +80,14 @@ class MemberController(
         return ResponseEntity.ok(updatedMember.toResponseDto())
     }
 
-    @Operation(summary = "delete member", description = "delete member")
+    @Operation(
+        summary = "delete member",
+        description = "delete member",
+        responses = [
+            ApiResponse(responseCode = "204", description = "Successful operation"),
+            ApiResponse(responseCode = "404", description = "There is no member", content = [Content(examples = [ExampleObject(name = "MemberNotFound", value = "Member not found", description = "No member has a matching ID")])])
+        ]
+    )
     @DeleteMapping("/id/{id}")
     fun deleteMember(@PathVariable id: String): ResponseEntity<Void> {
         memberService.deleteMember(id)
@@ -53,7 +95,13 @@ class MemberController(
         return ResponseEntity.noContent().build()
     }
 
-    @Operation(summary = "read all member", description = "read all member")
+    @Operation(
+        summary = "read all member",
+        description = "read all member",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation")
+        ]
+    )
     @GetMapping
     fun getAllMembers(): ResponseEntity<List<MemberResponseDto>> {
         val allMembers = memberService.getAllMembers()
@@ -61,7 +109,13 @@ class MemberController(
         return ResponseEntity.ok(allMembers.map { member: Member -> member.toResponseDto() })
     }
 
-    @Operation(summary = "read member by name", description = "read member by name")
+    @Operation(
+        summary = "read member by name",
+        description = "read member by name",
+        responses = [
+            ApiResponse(responseCode = "200", description = "Successful operation")
+        ]
+    )
     @GetMapping("/name/{name}")
     fun getMemberByName(@PathVariable name: String): ResponseEntity<MemberResponseDto> {
         val memberByName = memberService.getMemberByName(name)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/ExpenseRequestDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/ExpenseRequestDto.kt
@@ -3,6 +3,6 @@ package org.team_leg3nd.tarae.controller.dto.request
 data class ExpenseRequestDto(
     val description: String,
     val amount: Double,
-    val paidBy: List<String>,
-    val sharedWith: List<String>?
+    val paidBy: List<String>,  // Member ID
+    val sharedWith: List<String>? = null  // Member ID List
 )

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/ExpenseRequestDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/ExpenseRequestDto.kt
@@ -1,0 +1,8 @@
+package org.team_leg3nd.tarae.controller.dto.request
+
+data class ExpenseRequestDto(
+    val description: String,
+    val amount: Double,
+    val paidBy: List<String>,
+    val sharedWith: List<String>?
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/GroupRequestDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/GroupRequestDto.kt
@@ -1,0 +1,4 @@
+package org.team_leg3nd.tarae.controller.dto.request
+
+data class GroupRequestDto(val name: String)
+

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/GroupRequestDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/GroupRequestDto.kt
@@ -1,4 +1,9 @@
 package org.team_leg3nd.tarae.controller.dto.request
 
-data class GroupRequestDto(val name: String)
+data class GroupRequestDto(
+    val name: String,
+    val members: List<String>? = null,  // Member ID 리스트
+    val expenses: List<String>? = null  // Expense ID 리스트
+)
+
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/MemberRequestDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/MemberRequestDto.kt
@@ -1,0 +1,3 @@
+package org.team_leg3nd.tarae.controller.dto.request
+
+data class MemberRequestDto(val name: String)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/MemberRequestDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/request/MemberRequestDto.kt
@@ -1,3 +1,6 @@
 package org.team_leg3nd.tarae.controller.dto.request
 
-data class MemberRequestDto(val name: String)
+data class MemberRequestDto(
+    val name: String,
+    val paidExpenses: List<String>? = null  // Expense ID 리스트
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/ExpenseProjectionResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/ExpenseProjectionResponseDto.kt
@@ -1,0 +1,7 @@
+package org.team_leg3nd.tarae.controller.dto.response
+
+data class ExpenseProjectionResponseDto(
+    val id: String,
+    val description: String,
+    val amount: Double,
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/ExpenseResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/ExpenseResponseDto.kt
@@ -1,0 +1,9 @@
+package org.team_leg3nd.tarae.controller.dto.response
+
+data class ExpenseResponseDto(
+    val id: String,
+    val description: String,
+    val amount: Double,
+    val paidBy: List<String>,
+    val sharedWith: List<String>?
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/ExpenseResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/ExpenseResponseDto.kt
@@ -4,6 +4,6 @@ data class ExpenseResponseDto(
     val id: String,
     val description: String,
     val amount: Double,
-    val paidBy: List<String>,
-    val sharedWith: List<String>?
+    val paidBy: List<String>,  // Member 이름 리스트
+    val sharedWith: List<String>? = null
 )

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/ExpenseResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/ExpenseResponseDto.kt
@@ -4,6 +4,6 @@ data class ExpenseResponseDto(
     val id: String,
     val description: String,
     val amount: Double,
-    val paidBy: List<String>,  // Member 이름 리스트
-    val sharedWith: List<String>? = null
+    val paidBy: List<MemberProjectionResponseDto>,  // Member id 리스트
+    val sharedWith: List<MemberProjectionResponseDto>? = null
 )

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/GroupResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/GroupResponseDto.kt
@@ -1,0 +1,6 @@
+package org.team_leg3nd.tarae.controller.dto.response
+
+data class GroupResponseDto(
+    val id: String,
+    val name: String
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/GroupResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/GroupResponseDto.kt
@@ -2,5 +2,7 @@ package org.team_leg3nd.tarae.controller.dto.response
 
 data class GroupResponseDto(
     val id: String,
-    val name: String
+    val name: String,
+    val members: List<String>? = null,
+    val expenses: List<String>? = null
 )

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/GroupResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/GroupResponseDto.kt
@@ -3,6 +3,6 @@ package org.team_leg3nd.tarae.controller.dto.response
 data class GroupResponseDto(
     val id: String,
     val name: String,
-    val members: List<String>? = null,
-    val expenses: List<String>? = null
+    val members: List<MemberProjectionResponseDto>? = null,
+    val expenses: List<ExpenseProjectionResponseDto>? = null
 )

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/MemberProjectionResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/MemberProjectionResponseDto.kt
@@ -1,0 +1,6 @@
+package org.team_leg3nd.tarae.controller.dto.response
+
+data class MemberProjectionResponseDto(
+    val id: String,
+    val name: String
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/MemberResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/MemberResponseDto.kt
@@ -2,5 +2,6 @@ package org.team_leg3nd.tarae.controller.dto.response
 
 data class MemberResponseDto(
     val id: String,
-    val name: String
+    val name: String,
+    val paidExpenses: List<String>? = null
 )

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/MemberResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/MemberResponseDto.kt
@@ -1,0 +1,6 @@
+package org.team_leg3nd.tarae.controller.dto.response
+
+data class MemberResponseDto(
+    val id: String,
+    val name: String
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/MemberResponseDto.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/controller/dto/response/MemberResponseDto.kt
@@ -3,5 +3,5 @@ package org.team_leg3nd.tarae.controller.dto.response
 data class MemberResponseDto(
     val id: String,
     val name: String,
-    val paidExpenses: List<String>? = null
+    val paidExpenses: List<ExpenseProjectionResponseDto>? = null
 )

--- a/src/main/kotlin/org/team_leg3nd/tarae/entity/Expense.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/entity/Expense.kt
@@ -8,6 +8,6 @@ data class Expense(
     @Id val id: String? = null,
     val description: String,
     val amount: Double,
-    val paidBy: Member,
+    val paidBy: List<Member>,
     val sharedWith: List<Member>? = null
 )

--- a/src/main/kotlin/org/team_leg3nd/tarae/entity/Expense.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/entity/Expense.kt
@@ -1,0 +1,13 @@
+package org.team_leg3nd.tarae.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document(collection = "expenses")
+data class Expense(
+    @Id val id: String? = null,
+    val description: String,
+    val amount: Double,
+    val paidBy: Member,
+    val sharedWith: List<Member>? = null
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/entity/Group.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/entity/Group.kt
@@ -1,0 +1,12 @@
+package org.team_leg3nd.tarae.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document(collection = "groups")
+data class Group(
+    @Id val id: String? = null,
+    val name: String,
+    val members: List<Member>? = null,
+    val expenses: List<Expense>? = null
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/entity/Member.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/entity/Member.kt
@@ -1,0 +1,11 @@
+package org.team_leg3nd.tarae.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document(collection = "members")
+data class Member(
+    @Id val id: String? = null,
+    val name: String,
+    val paidExpenses: List<Expense>? = null
+)

--- a/src/main/kotlin/org/team_leg3nd/tarae/exception/ExpenseNotFoundException.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/exception/ExpenseNotFoundException.kt
@@ -1,0 +1,3 @@
+package org.team_leg3nd.tarae.exception
+
+class ExpenseNotFoundException(message: String?): Throwable(message)

--- a/src/main/kotlin/org/team_leg3nd/tarae/exception/ExpenseNotFoundException.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/exception/ExpenseNotFoundException.kt
@@ -1,3 +1,3 @@
 package org.team_leg3nd.tarae.exception
 
-class ExpenseNotFoundException(message: String?): Throwable(message)
+class ExpenseNotFoundException(message: String?): RuntimeException(message)

--- a/src/main/kotlin/org/team_leg3nd/tarae/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,41 @@
+package org.team_leg3nd.tarae.exception
+
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val logger = KotlinLogging.logger {}
+
+    @ExceptionHandler(ExpenseNotFoundException::class)
+    fun handleExpenseNotFoundException(e: ExpenseNotFoundException): ResponseEntity<String> {
+        logger.error { e.message }
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.message)
+    }
+
+    @ExceptionHandler(MemberNotFoundException::class)
+    fun handleMemberNotFoundException(e: MemberNotFoundException): ResponseEntity<String> {
+        logger.error { e.message }
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.message)
+    }
+
+    @ExceptionHandler(GroupNotFoundException::class)
+    fun handleGroupNotFoundException(e: GroupNotFoundException): ResponseEntity<String> {
+        logger.error { e.message }
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.message)
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleInternalServerException(e: Exception): ResponseEntity<String> {
+        logger.error { e.message }
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal server error")
+    }
+}

--- a/src/main/kotlin/org/team_leg3nd/tarae/exception/GroupNotFoundException.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/exception/GroupNotFoundException.kt
@@ -1,3 +1,3 @@
 package org.team_leg3nd.tarae.exception
 
-class GroupNotFoundException(message: String?): Throwable(message)
+class GroupNotFoundException(message: String?): RuntimeException(message)

--- a/src/main/kotlin/org/team_leg3nd/tarae/exception/GroupNotFoundException.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/exception/GroupNotFoundException.kt
@@ -1,0 +1,3 @@
+package org.team_leg3nd.tarae.exception
+
+class GroupNotFoundException(message: String?): Throwable(message)

--- a/src/main/kotlin/org/team_leg3nd/tarae/exception/MemberNotFoundException.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/exception/MemberNotFoundException.kt
@@ -1,0 +1,3 @@
+package org.team_leg3nd.tarae.exception
+
+class MemberNotFoundException(message: String?): Throwable(message)

--- a/src/main/kotlin/org/team_leg3nd/tarae/exception/MemberNotFoundException.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/exception/MemberNotFoundException.kt
@@ -1,3 +1,3 @@
 package org.team_leg3nd.tarae.exception
 
-class MemberNotFoundException(message: String?): Throwable(message)
+class MemberNotFoundException(message: String?): RuntimeException(message)

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/ExpenseRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/ExpenseRepository.kt
@@ -6,7 +6,5 @@ import org.team_leg3nd.tarae.entity.Expense
 
 @Repository
 interface ExpenseRepository : MongoRepository<Expense, String> {
-    fun findByPaidBy(name: String): List<Expense>
-
     override fun findAll(): List<Expense>
 }

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/ExpenseRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/ExpenseRepository.kt
@@ -1,0 +1,6 @@
+package org.team_leg3nd.tarae.repository
+
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.team_leg3nd.tarae.entity.Expense
+
+interface ExpenseRepository : MongoRepository<Expense, String>

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/ExpenseRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/ExpenseRepository.kt
@@ -6,5 +6,7 @@ import org.team_leg3nd.tarae.entity.Expense
 
 @Repository
 interface ExpenseRepository : MongoRepository<Expense, String> {
-    fun findByPaidBy(id: String): List<Expense>
+    fun findByPaidBy(name: String): List<Expense>
+
+    override fun findAll(): List<Expense>
 }

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/ExpenseRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/ExpenseRepository.kt
@@ -1,6 +1,10 @@
 package org.team_leg3nd.tarae.repository
 
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
 import org.team_leg3nd.tarae.entity.Expense
 
-interface ExpenseRepository : MongoRepository<Expense, String>
+@Repository
+interface ExpenseRepository : MongoRepository<Expense, String> {
+    fun findByPaidBy(id: String): List<Expense>
+}

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/GroupRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/GroupRepository.kt
@@ -7,4 +7,6 @@ import org.team_leg3nd.tarae.entity.Group
 @Repository
 interface GroupRepository : MongoRepository<Group, String> {
     fun findByName(name: String): Group?
+
+    override fun findAll(): List<Group>
 }

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/GroupRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/GroupRepository.kt
@@ -1,0 +1,6 @@
+package org.team_leg3nd.tarae.repository
+
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.team_leg3nd.tarae.entity.Group
+
+interface GroupRepository : MongoRepository<Group, String>

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/GroupRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/GroupRepository.kt
@@ -1,6 +1,10 @@
 package org.team_leg3nd.tarae.repository
 
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
 import org.team_leg3nd.tarae.entity.Group
 
-interface GroupRepository : MongoRepository<Group, String>
+@Repository
+interface GroupRepository : MongoRepository<Group, String> {
+    fun findByName(name: String): Group?
+}

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/MemberRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/MemberRepository.kt
@@ -7,5 +7,7 @@ import org.team_leg3nd.tarae.entity.Member
 
 @Repository
 interface MemberRepository : MongoRepository<Member, String> {
-    fun findByName(name: String): List<Member>
+    fun findByName(name: String): Member?
+
+    override fun findAll(): List<Member>
 }

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/MemberRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/MemberRepository.kt
@@ -1,7 +1,11 @@
 package org.team_leg3nd.tarae.repository
 
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
 import org.team_leg3nd.tarae.entity.Member
 
 
-interface MemberRepository : MongoRepository<Member, String>
+@Repository
+interface MemberRepository : MongoRepository<Member, String> {
+    fun findByName(name: String): List<Member>
+}

--- a/src/main/kotlin/org/team_leg3nd/tarae/repository/MemberRepository.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/repository/MemberRepository.kt
@@ -1,0 +1,7 @@
+package org.team_leg3nd.tarae.repository
+
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.team_leg3nd.tarae.entity.Member
+
+
+interface MemberRepository : MongoRepository<Member, String>

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/ExpenseService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/ExpenseService.kt
@@ -1,24 +1,17 @@
 package org.team_leg3nd.tarae.service
 
 import org.springframework.stereotype.Service
-import org.team_leg3nd.tarae.controller.dto.request.ExpenseRequestDto
 import org.team_leg3nd.tarae.entity.Expense
 import org.team_leg3nd.tarae.exception.*
 import org.team_leg3nd.tarae.repository.ExpenseRepository
-import org.team_leg3nd.tarae.repository.MemberRepository
 
 @Service
 class ExpenseService(
     private val expenseRepository: ExpenseRepository,
-    private val memberRepository: MemberRepository
 ) {
 
     // 지출 생성
-    fun createExpense(expenseRequestDto: ExpenseRequestDto): Expense {
-        val paidByMembers = expenseRequestDto.paidBy.map { memberRepository.findById(it).orElseThrow { MemberNotFoundException("Member not found") } }
-        val sharedWithMembers = expenseRequestDto.sharedWith?.map { memberRepository.findById(it).orElseThrow { MemberNotFoundException("Member not found") } }
-
-        val expense = Expense(description = expenseRequestDto.description, amount = expenseRequestDto.amount, paidBy = paidByMembers, sharedWith = sharedWithMembers)
+    fun createExpense(expense: Expense): Expense {
         return expenseRepository.save(expense)
     }
 
@@ -28,12 +21,10 @@ class ExpenseService(
     }
 
     // 지출 수정
-    fun updateExpense(id: String, expenseRequestDto: ExpenseRequestDto): Expense {
+    fun updateExpense(id: String, expense: Expense): Expense {
         val existingExpense = expenseRepository.findById(id).orElseThrow { ExpenseNotFoundException("Expense not found") }
-        val paidByMembers = expenseRequestDto.paidBy.map { memberRepository.findById(it).orElseThrow { MemberNotFoundException("Member not found") } }
-        val sharedWithMembers = expenseRequestDto.sharedWith?.map { memberRepository.findById(it).orElseThrow { MemberNotFoundException("Member not found") } }
 
-        val updatedExpense = existingExpense.copy(description = expenseRequestDto.description, amount = expenseRequestDto.amount, paidBy = paidByMembers, sharedWith = sharedWithMembers)
+        val updatedExpense = existingExpense.copy(description = expense.description, amount = expense.amount, paidBy = expense.paidBy, sharedWith = expense.sharedWith)
         return expenseRepository.save(updatedExpense)
     }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/ExpenseService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/ExpenseService.kt
@@ -38,11 +38,6 @@ class ExpenseService(
     fun getAllExpenses(): List<Expense> {
         return expenseRepository.findAll()
     }
-
-    // Expense.paidBy로 지출 조회
-    fun getExpenseByPaidBy(paidBy: String): List<Expense> {
-        return expenseRepository.findByPaidBy(paidBy)
-    }
 }
 
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/ExpenseService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/ExpenseService.kt
@@ -42,6 +42,16 @@ class ExpenseService(
         val expense = expenseRepository.findById(id).orElseThrow { ExpenseNotFoundException("Expense not found") }
         expenseRepository.delete(expense)
     }
+
+    // 전체 지출 조회
+    fun getAllExpenses(): List<Expense> {
+        return expenseRepository.findAll()
+    }
+
+    // Expense.paidBy로 지출 조회
+    fun getExpenseByPaidBy(paidBy: String): List<Expense> {
+        return expenseRepository.findByPaidBy(paidBy)
+    }
 }
 
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/ExpenseService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/ExpenseService.kt
@@ -1,0 +1,21 @@
+package org.team_leg3nd.tarae.service
+
+import org.springframework.stereotype.Service
+import org.team_leg3nd.tarae.entity.Expense
+import org.team_leg3nd.tarae.repository.ExpenseRepository
+
+@Service
+class ExpenseService(private val expenseRepository: ExpenseRepository) {
+
+    fun createExpense(expense: Expense) = expenseRepository.save(expense)
+
+    fun getExpenseById(id: String) = expenseRepository.findById(id).orElse(null)
+
+    fun getExpensesByMember(memberId: String) = expenseRepository.findByPaidBy(memberId)
+
+    fun updateExpense(id: String, expense: Expense) = expenseRepository.save(expense.copy(id = id))
+
+    fun deleteExpense(id: String) = expenseRepository.deleteById(id)
+
+    fun getAllExpenses() = expenseRepository.findAll()
+}

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/GroupService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/GroupService.kt
@@ -1,19 +1,48 @@
 package org.team_leg3nd.tarae.service
 
 import org.springframework.stereotype.Service
+import org.team_leg3nd.tarae.controller.dto.request.GroupRequestDto
 import org.team_leg3nd.tarae.entity.Group
+import org.team_leg3nd.tarae.repository.ExpenseRepository
 import org.team_leg3nd.tarae.repository.GroupRepository
+import org.team_leg3nd.tarae.repository.MemberRepository
+import org.team_leg3nd.tarae.exception.*
 
 @Service
-class GroupService(private val groupRepository: GroupRepository) {
+class GroupService(
+    private val groupRepository: GroupRepository,
+    private val memberRepository: MemberRepository,
+    private val expenseRepository: ExpenseRepository
+) {
 
-    fun createGroup(group: Group) = groupRepository.save(group)
+    // 그룹 생성
+    fun createGroup(groupRequestDto: GroupRequestDto): Group {
+        val members = groupRequestDto.members?.let { memberRepository.findAllById(it) } ?: emptyList()
+        val expenses = groupRequestDto.expenses?.let { expenseRepository.findAllById(it) } ?: emptyList()
 
-    fun getGroupById(id: String) = groupRepository.findById(id).orElse(null)
+        val group = Group(name = groupRequestDto.name, members = members, expenses = expenses)
+        return groupRepository.save(group)
+    }
 
-    fun updateGroup(id: String, group: Group) = groupRepository.save(group.copy(id = id))
+    // 그룹 조회
+    fun getGroup(id: String): Group {
+        return groupRepository.findById(id).orElseThrow { GroupNotFoundException("Group not found") }
+    }
 
-    fun deleteGroup(id: String) = groupRepository.deleteById(id)
+    // 그룹 수정
+    fun updateGroup(id: String, groupRequestDto: GroupRequestDto): Group {
+        val existingGroup = groupRepository.findById(id).orElseThrow { GroupNotFoundException("Group not found") }
+        val members = groupRequestDto.members?.let { memberRepository.findAllById(it) } ?: existingGroup.members
+        val expenses = groupRequestDto.expenses?.let { expenseRepository.findAllById(it) } ?: existingGroup.expenses
 
-    fun getAllGroups() = groupRepository.findAll()
+        val updatedGroup = existingGroup.copy(name = groupRequestDto.name, members = members, expenses = expenses)
+        return groupRepository.save(updatedGroup)
+    }
+
+    // 그룹 삭제
+    fun deleteGroup(id: String) {
+        val group = groupRepository.findById(id).orElseThrow { GroupNotFoundException("Group not found") }
+        groupRepository.delete(group)
+    }
 }
+

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/GroupService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/GroupService.kt
@@ -1,0 +1,19 @@
+package org.team_leg3nd.tarae.service
+
+import org.springframework.stereotype.Service
+import org.team_leg3nd.tarae.entity.Group
+import org.team_leg3nd.tarae.repository.GroupRepository
+
+@Service
+class GroupService(private val groupRepository: GroupRepository) {
+
+    fun createGroup(group: Group) = groupRepository.save(group)
+
+    fun getGroupById(id: String) = groupRepository.findById(id).orElse(null)
+
+    fun updateGroup(id: String, group: Group) = groupRepository.save(group.copy(id = id))
+
+    fun deleteGroup(id: String) = groupRepository.deleteById(id)
+
+    fun getAllGroups() = groupRepository.findAll()
+}

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/GroupService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/GroupService.kt
@@ -1,26 +1,17 @@
 package org.team_leg3nd.tarae.service
 
 import org.springframework.stereotype.Service
-import org.team_leg3nd.tarae.controller.dto.request.GroupRequestDto
 import org.team_leg3nd.tarae.entity.Group
-import org.team_leg3nd.tarae.repository.ExpenseRepository
 import org.team_leg3nd.tarae.repository.GroupRepository
-import org.team_leg3nd.tarae.repository.MemberRepository
 import org.team_leg3nd.tarae.exception.*
 
 @Service
 class GroupService(
     private val groupRepository: GroupRepository,
-    private val memberRepository: MemberRepository,
-    private val expenseRepository: ExpenseRepository
 ) {
 
     // 그룹 생성
-    fun createGroup(groupRequestDto: GroupRequestDto): Group {
-        val members = groupRequestDto.members?.let { memberRepository.findAllById(it) } ?: emptyList()
-        val expenses = groupRequestDto.expenses?.let { expenseRepository.findAllById(it) } ?: emptyList()
-
-        val group = Group(name = groupRequestDto.name, members = members, expenses = expenses)
+    fun createGroup(group: Group): Group {
         return groupRepository.save(group)
     }
 
@@ -30,12 +21,10 @@ class GroupService(
     }
 
     // 그룹 수정
-    fun updateGroup(id: String, groupRequestDto: GroupRequestDto): Group {
+    fun updateGroup(id: String, group: Group): Group {
         val existingGroup = groupRepository.findById(id).orElseThrow { GroupNotFoundException("Group not found") }
-        val members = groupRequestDto.members?.let { memberRepository.findAllById(it) } ?: existingGroup.members
-        val expenses = groupRequestDto.expenses?.let { expenseRepository.findAllById(it) } ?: existingGroup.expenses
 
-        val updatedGroup = existingGroup.copy(name = groupRequestDto.name, members = members, expenses = expenses)
+        val updatedGroup = existingGroup.copy(name = group.name, members = group.members, expenses = group.expenses)
         return groupRepository.save(updatedGroup)
     }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/GroupService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/GroupService.kt
@@ -44,5 +44,15 @@ class GroupService(
         val group = groupRepository.findById(id).orElseThrow { GroupNotFoundException("Group not found") }
         groupRepository.delete(group)
     }
+
+    // 전체 그룹 조회
+    fun getAllGroups(): List<Group> {
+        return groupRepository.findAll()
+    }
+
+    // Group.name으로 그룹 조회
+    fun getGroupByName(name: String): Group? {
+        return groupRepository.findByName(name)
+    }
 }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/MemberService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/MemberService.kt
@@ -1,22 +1,17 @@
 package org.team_leg3nd.tarae.service
 
 import org.springframework.stereotype.Service
-import org.team_leg3nd.tarae.controller.dto.request.MemberRequestDto
 import org.team_leg3nd.tarae.entity.Member
 import org.team_leg3nd.tarae.repository.MemberRepository
 import org.team_leg3nd.tarae.exception.*
-import org.team_leg3nd.tarae.repository.ExpenseRepository
 
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
-    private val expenseRepository: ExpenseRepository
 ) {
 
     // 멤버 생성
-    fun createMember(memberRequestDto: MemberRequestDto): Member {
-        val paidExpenses = memberRequestDto.paidExpenses?.let { expenseRepository.findAllById(it) } ?: emptyList()
-        val member = Member(name = memberRequestDto.name, paidExpenses = paidExpenses)
+    fun createMember(member: Member): Member {
         return memberRepository.save(member)
     }
 
@@ -26,11 +21,10 @@ class MemberService(
     }
 
     // 멤버 수정
-    fun updateMember(id: String, memberRequestDto: MemberRequestDto): Member {
+    fun updateMember(id: String, member: Member): Member {
         val existingMember = memberRepository.findById(id).orElseThrow { MemberNotFoundException("Member not found") }
-        val paidExpenses = memberRequestDto.paidExpenses?.let { expenseRepository.findAllById(it) } ?: existingMember.paidExpenses
 
-        val updatedMember = existingMember.copy(name = memberRequestDto.name, paidExpenses = paidExpenses)
+        val updatedMember = existingMember.copy(name = member.name, paidExpenses = member.paidExpenses)
         return memberRepository.save(updatedMember)
     }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/MemberService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/MemberService.kt
@@ -1,21 +1,43 @@
 package org.team_leg3nd.tarae.service
 
 import org.springframework.stereotype.Service
+import org.team_leg3nd.tarae.controller.dto.request.MemberRequestDto
 import org.team_leg3nd.tarae.entity.Member
 import org.team_leg3nd.tarae.repository.MemberRepository
+import org.team_leg3nd.tarae.exception.*
+import org.team_leg3nd.tarae.repository.ExpenseRepository
 
 @Service
-class MemberService(private val memberRepository: MemberRepository) {
+class MemberService(
+    private val memberRepository: MemberRepository,
+    private val expenseRepository: ExpenseRepository
+) {
 
-    fun createMember(member: Member) = memberRepository.save(member)
+    // 멤버 생성
+    fun createMember(memberRequestDto: MemberRequestDto): Member {
+        val paidExpenses = memberRequestDto.paidExpenses?.let { expenseRepository.findAllById(it) } ?: emptyList()
+        val member = Member(name = memberRequestDto.name, paidExpenses = paidExpenses)
+        return memberRepository.save(member)
+    }
 
-    fun getMemberById(id: String) = memberRepository.findById(id).orElse(null)
+    // 멤버 조회
+    fun getMember(id: String): Member {
+        return memberRepository.findById(id).orElseThrow { MemberNotFoundException("Member not found") }
+    }
 
-    fun getMembersByName(name: String) = memberRepository.findByName(name)
+    // 멤버 수정
+    fun updateMember(id: String, memberRequestDto: MemberRequestDto): Member {
+        val existingMember = memberRepository.findById(id).orElseThrow { MemberNotFoundException("Member not found") }
+        val paidExpenses = memberRequestDto.paidExpenses?.let { expenseRepository.findAllById(it) } ?: existingMember.paidExpenses
 
-    fun updateMember(id: String, member: Member) = memberRepository.save(member.copy(id = id))
+        val updatedMember = existingMember.copy(name = memberRequestDto.name, paidExpenses = paidExpenses)
+        return memberRepository.save(updatedMember)
+    }
 
-    fun deleteMember(id: String) = memberRepository.deleteById(id)
-
-    fun getAllMembers() = memberRepository.findAll()
+    // 멤버 삭제
+    fun deleteMember(id: String) {
+        val member = memberRepository.findById(id).orElseThrow { MemberNotFoundException("Member not found") }
+        memberRepository.delete(member)
+    }
 }
+

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/MemberService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/MemberService.kt
@@ -39,5 +39,15 @@ class MemberService(
         val member = memberRepository.findById(id).orElseThrow { MemberNotFoundException("Member not found") }
         memberRepository.delete(member)
     }
+
+    // 전체 멤버 조회
+    fun getAllMembers(): List<Member> {
+        return memberRepository.findAll()
+    }
+
+    // Member.name으로 멤버 조회
+    fun getMemberByName(name: String): Member? {
+        return memberRepository.findByName(name)
+    }
 }
 

--- a/src/main/kotlin/org/team_leg3nd/tarae/service/MemberService.kt
+++ b/src/main/kotlin/org/team_leg3nd/tarae/service/MemberService.kt
@@ -1,0 +1,21 @@
+package org.team_leg3nd.tarae.service
+
+import org.springframework.stereotype.Service
+import org.team_leg3nd.tarae.entity.Member
+import org.team_leg3nd.tarae.repository.MemberRepository
+
+@Service
+class MemberService(private val memberRepository: MemberRepository) {
+
+    fun createMember(member: Member) = memberRepository.save(member)
+
+    fun getMemberById(id: String) = memberRepository.findById(id).orElse(null)
+
+    fun getMembersByName(name: String) = memberRepository.findByName(name)
+
+    fun updateMember(id: String, member: Member) = memberRepository.save(member.copy(id = id))
+
+    fun deleteMember(id: String) = memberRepository.deleteById(id)
+
+    fun getAllMembers() = memberRepository.findAll()
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## 기능
Dango의 Group, Member, Expense를 MongoDB에 CRUD 할 수 있는 API

## 작업 상세
- Controller, Service, Repository 3 layer 기반 작업  
  - Controller에서 RequestDTO, ResponseDTO를 통해 요청과 응답 처리했습니다.  
    Controller에서 RequestDTO -> Entity, Entity -> ResponseDTO 변환을 책임지게 했습니다.  
  - Service에서 Entity에 대한 처리 로직 추가했습니다. 현재는 MongoDB에 CRUD하는 로직과 예외를 던지는 로직이 있습니다.
  - Repository에서 MongoDB에 대한 실제 CRUD 작업을 합니다.  
- GlobalExceptionHandler 추가
  - @RestControllerAdvice로 Exception에 대한 처리를 중앙화했습니다.
  - 클라이언트에서 발생시킬 수 있는 Exception을 정의했습니다.  그 외의 Exception은 internal server error로 처리했습니다.  
- Logback 추가
  - logging을 위해 logback 추가했습니다.   
- API 명세서를 위해 swagger 추가  
  - API 명세서를 위해 swagger를 추가하고 요청 샘플 및 응답 샘플을 정리했습니다.

## 비고
- 코드 리뷰하고 클라이언트 요청 사항을 만족시킬 수 있는 기능까지 고도화되면 테스트 코드도 추가하겠습니다. 
